### PR TITLE
Port patch from https://github.com/jackc/pgtype/pull/13/

### DIFF
--- a/pgtype/int4_array.go
+++ b/pgtype/int4_array.go
@@ -80,6 +80,44 @@ func (dst *Int4Array) Set(src interface{}) error {
 			}
 		}
 
+	case []int64:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint64:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
 	default:
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
@@ -117,6 +155,24 @@ func (src *Int4Array) AssignTo(dst interface{}) error {
 
 		case *[]uint32:
 			*v = make([]uint32, len(src.Elements))
+			for i := range src.Elements {
+				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+					return err
+				}
+			}
+			return nil
+
+		case *[]int64:
+			*v = make([]int64, len(src.Elements))
+			for i := range src.Elements {
+				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+					return err
+				}
+			}
+			return nil
+
+		case *[]uint64:
+			*v = make([]uint64, len(src.Elements))
 			for i := range src.Elements {
 				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
 					return err

--- a/pgtype/int4_array_test.go
+++ b/pgtype/int4_array_test.go
@@ -60,7 +60,21 @@ func TestInt4ArraySet(t *testing.T) {
 		expectedError bool
 	}{
 		{
+			source: []int64{1},
+			result: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
 			source: []int32{1},
+			result: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: []uint64{1},
 			result: pgtype.Int4Array{
 				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}},


### PR DESCRIPTION
We cannot use Go modules in code yet, so we have stuck with pgx v3. An improvement related to []int64 was made in pgtype (requiring v4 of pgx and go modules) so we port it